### PR TITLE
Add data-href as an option for the lightcase target link

### DIFF
--- a/lightcase.js
+++ b/lightcase.js
@@ -162,7 +162,7 @@
 				,caption : $object.children('img').attr('alt')
 				,url : lightcase.verifyDataUrl($object.attr('data-href') || $object.attr('href'))
 				,rel : $object.attr('data-rel')
-				,type : lightcase.settings.type ? lightcase.settings.type : lightcase.verifyDataType($object.attr('href'))
+				,type : lightcase.settings.type ? lightcase.settings.type : lightcase.verifyDataType($object.attr('data-href') || $object.attr('href'))
 				,isPartOfSequence : lightcase.isPartOfSequence($object.attr('data-rel'), ':')
 				,isPartOfSequenceWithSlideshow : lightcase.isPartOfSequence($object.attr('data-rel'), ':slideshow')
 				,currentIndex : $('[data-rel="' + $object.attr('data-rel') + '"]').index($object)


### PR DESCRIPTION
Added the possibility to use a `data-href` attribute instead of `href` so elements other than anchor tags can be used.
