### PR TITLE
Remove BOM from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "lightcase",
   "description": "The smart and flexible Lightbox Plugin.",
   "keywords": [


### PR DESCRIPTION
The BOM (Byte Order Marker) at the beginning of the package.json is not fully supported by `npm` and other tools. Webpack fails with an error: `BowerComponents/lightcase/package.json (directory description file): SyntaxError: Unexpected token`, npm itself has problems with `install --save` and `update --save`.

Depending on which way you look at the standards JSON with UTF-8 BOM isn't valid json either.

Since none of the other files in the repository have a BOM, remove it to avoid problems.