### PR TITLE
Replace deprecated load()

### DIFF
--- a/src/js/lightcase.js
+++ b/src/js/lightcase.js
@@ -549,7 +549,7 @@
 					break;
 				default:
 					if (_self.objectData.url) {
-						$object.on('load', function() {
+						$object.on('load', function () {
 							_self._showContent($object);
 						});
 						$object.error(function () {

--- a/src/js/lightcase.js
+++ b/src/js/lightcase.js
@@ -549,7 +549,7 @@
 					break;
 				default:
 					if (_self.objectData.url) {
-						$object.load(function () {
+						$object.on('load', function() {
 							_self._showContent($object);
 						});
 						$object.error(function () {


### PR DESCRIPTION
This PR replaces load() which is [deprecated](http://api.jquery.com/load-event/) since version 1.8 of jQuery.