### PR TITLE
Replace deprecated error()

### DIFF
--- a/src/js/lightcase.js
+++ b/src/js/lightcase.js
@@ -552,7 +552,7 @@
 						$object.load(function () {
 							_self._showContent($object);
 						});
-						$object.error(function () {
+						$object.on('error', function () {
 							_self.error();
 						});
 					} else {


### PR DESCRIPTION
This PR replaces error() which is [deprecated](https://api.jquery.com/error/) since version 1.8 of jQuery.