### PR TITLE
Adding a link target from src attribute

### DIFF
--- a/src/js/lightcase.js
+++ b/src/js/lightcase.js
@@ -253,7 +253,7 @@
 		 * @return	{string}
 		 */
 		_determineLinkTarget: function () {
-			return _self.settings.href || $(_self.origin).attr(_self._prefixAttributeName('href')) || $(_self.origin).attr('href');
+			return _self.settings.href || $(_self.origin).attr(_self._prefixAttributeName('href')) || $(_self.origin).attr('href') || $(_self.origin).attr('src');
 		},
 
 		/**


### PR DESCRIPTION
This is a small hack. A didn't want to create a link (<a>) around all images, but just let the user click on an image to open lightcase.

To work, the launch function has to be changed to :

jQuery(document).ready(function ($) {
    $('img[data-rel^=lightcase]').lightcase();
    $('img[data-rel^=lightcase]').css('cursor', 'pointer');
});

It also changes the cursor to pointer for all images with data-rel="lightcase".