### PR TITLE
add X-Ajax-Location check

### DIFF
--- a/src/js/lightcase.js
+++ b/src/js/lightcase.js
@@ -529,7 +529,7 @@
 							data: _self.objectData.requestData,
 							success: function (data, textStatus, jqXHR) {
 								// Check for X-Ajax-Location
-								if (typeof jqXHR.getResponseHeader('X-Ajax-Location') !== 'undefined' && jqXHR.getResponseHeader('X-Ajax-Location') !== null) {
+								if (jqXHR.getResponseHeader('X-Ajax-Location')) {
 									_self.objectData.url = jqXHR.getResponseHeader('X-Ajax-Location');
 									_self._loadObject($object);
 								}

--- a/src/js/lightcase.js
+++ b/src/js/lightcase.js
@@ -528,13 +528,20 @@
 							dataType: _self.objectData.requestDataType,
 							data: _self.objectData.requestData,
 							success: function (data, textStatus, jqXHR) {
-								// Unserialize if data is transferred as json
-								if (_self.objectData.requestDataType === 'json') {
-									_self.objectData.data = data;
-								} else {
-									$object.html(data);
+								// Check for X-Ajax-Location
+								if (typeof jqXHR.getResponseHeader('X-Ajax-Location') !== 'undefined' && jqXHR.getResponseHeader('X-Ajax-Location') !== null) {
+									_self.objectData.url = jqXHR.getResponseHeader('X-Ajax-Location');
+									_self._loadObject($object);
 								}
-								_self._showContent($object);
+								else {
+									// Unserialize if data is transferred as json
+									if (_self.objectData.requestDataType === 'json') {
+										_self.objectData.data = data;
+									} else {
+										$object.html(data);
+									}
+									_self._showContent($object);
+								}
 							},
 							error: function (jqXHR, textStatus, errorThrown) {
 								_self.error();


### PR DESCRIPTION
Servers might respond with an `X-Ajax-Location` header, instead of a regular `Location` header, when the request is done via AJAX. In that case, Lightcase would simply display empty content, when used via 
```JavaScript
type: 'ajax'
```

This PR adds a check for the `X-Ajax-Location` header and executes `_loadObject` again with the new URL.