### PR TITLE
Improved _getFileUrlSuffix function to get the suffix of files from external urls

### DIFF
--- a/src/js/lightcase.js
+++ b/src/js/lightcase.js
@@ -793,7 +793,7 @@
 		 */
 		_getFileUrlSuffix: function (url) {
 			var re = /(?:\.([^.]+))?$/;
-            return re.exec(url.toLowerCase())[1]; 
+			return re.exec(url.toLowerCase())[1]; 
 		},
 
 		/**

--- a/src/js/lightcase.js
+++ b/src/js/lightcase.js
@@ -792,7 +792,8 @@
 		 * @return	{string}
 		 */
 		_getFileUrlSuffix: function (url) {
-			return url.toLowerCase().split('?')[0].split('.')[1];
+			var re = /(?:\.([^.]+))?$/;
+            return re.exec(url.toLowerCase())[1]; 
 		},
 
 		/**


### PR DESCRIPTION
I had an issue with the library, respectively it failed to 'label' properly .mp4 video files loaded from external sources. It was getting the string after the first '.' as the extension. 

I made some changes on the _getFileUrlSuffix function and it fixed the problem. I made tests and all the extensions were retrieved correctly.
Here you have a jsfiddle example: https://jsfiddle.net/zv53qrpj/1/ 

Thank you and great work with the library!