### PR TITLE
Support for Data URLs

### DIFF
--- a/src/js/lightcase.js
+++ b/src/js/lightcase.js
@@ -835,8 +835,9 @@
 			//checking if user defined type is valid
 			if (_self.settings.type) {
 				for (var key in typeMapping) {
-					if (key === _self.settings.type)
-					return _self.settings.type;
+					if (key === _self.settings.type) {
+						return _self.settings.type;
+					}
 				}
 			}
 

--- a/src/js/lightcase.js
+++ b/src/js/lightcase.js
@@ -230,7 +230,7 @@
 				requestData: _self.settings.ajax.data,
 				requestDataType: _self.settings.ajax.dataType,
 				rel: $object.attr(_self._determineAttributeSelector()),
-				type: _self.settings.type || _self._verifyDataType(_self._determineUrl()),
+				type: _self._verifyDataType(_self._determineUrl()),
 				isPartOfSequence: _self.settings.useAsCollection || _self._isPartOfSequence($object.attr(_self.settings.attr), ':'),
 				isPartOfSequenceWithSlideshow: _self._isPartOfSequence($object.attr(_self.settings.attr), ':slideshow'),
 				currentIndex: $(_self._determineAttributeSelector()).index($object),
@@ -353,41 +353,40 @@
 		_normalizeUrl: function (url) {
 			var srcExp = /^\d+$/;
 
-            var urlParser = function (str) {
-                var src = {
-                    width: 0,
-                    density: 0
-                };
+            		var urlParser = function (str) {
+                		var src = {
+                    			width: 0,
+                    			density: 0
+                		};
 
-                str.trim().split(/\s+/).forEach(function (url, i) {
-                    if (i === 0) {
-                        return src.url = url;
-                    }
+                		str.trim().split(/\s+/).forEach(function (url, i) {
+                   			if (i === 0) {
+                        			return src.url = url;
+                    			}
 
-                    var value = url.substring(0, url.length - 1),
-                        lastChar = url[url.length - 1],
-                        intVal = parseInt(value, 10),
-                        floatVal = parseFloat(value);
-                    if (lastChar === 'w' && srcExp.test(value)) {
-                        src.width = intVal;
-                    } else if (lastChar === 'h' && srcExp.test(value)) {
-                        src.height = intVal;
-                    } else if (lastChar === 'x' && !isNaN(floatVal)) {
-                        src.density = floatVal;
-                    }
-                });
+                    			var value = url.substring(0, url.length - 1),
+                        		lastChar = url[url.length - 1],
+                        		intVal = parseInt(value, 10),
+                        		floatVal = parseFloat(value);
+					if (lastChar === 'w' && srcExp.test(value)) {
+						src.width = intVal;
+					} else if (lastChar === 'h' && srcExp.test(value)) {
+						src.height = intVal;
+					} else if (lastChar === 'x' && !isNaN(floatVal)) {
+						src.density = floatVal;
+					}
+				});
 
-                return src;
-            };
+                		return src;
+            		};
 
-            //data URL detected (no split)
-            if (url.indexOf("data:") === 0)
-            {
-                return [urlParser(url)];
-            }
+			// Data URL detected (no split)
+			if (url.indexOf('data:') === 0) {
+				return [urlParser(url)];
+			}
 
-            //regular URL, normal behavior
-            return url.split(',').map(urlParser);
+			// Regular URL, normal behavior
+			return url.split(',').map(urlParser);
 		},
 
 		/**

--- a/src/js/lightcase.js
+++ b/src/js/lightcase.js
@@ -832,13 +832,13 @@
 				return false;
 			}
 			
-            //checking if user defined type is valid
-            if (_self.settings.type) {
-                for (var key in typeMapping) {
-                    if (key === _self.settings.type)
-                        return _self.settings.type;
-                }
-            }
+			//checking if user defined type is valid
+			if (_self.settings.type) {
+				for (var key in typeMapping) {
+					if (key === _self.settings.type)
+					return _self.settings.type;
+				}
+			}
 
 			// Verify the dataType of url according to typeMapping which
 			// has been defined in settings.

--- a/src/js/lightcase.js
+++ b/src/js/lightcase.js
@@ -353,32 +353,41 @@
 		_normalizeUrl: function (url) {
 			var srcExp = /^\d+$/;
 
-			return url.split(',').map(function (str) {
-				var src = {
-					width: 0,
-					density: 0
-				};
+            var urlParser = function (str) {
+                var src = {
+                    width: 0,
+                    density: 0
+                };
 
-				str.trim().split(/\s+/).forEach(function (url, i) {
-					if (i === 0) {
-						return src.url = url;
-					}
+                str.trim().split(/\s+/).forEach(function (url, i) {
+                    if (i === 0) {
+                        return src.url = url;
+                    }
 
-					var value = url.substring(0, url.length - 1),
-						lastChar = url[url.length - 1],
-						intVal = parseInt(value, 10),
-						floatVal = parseFloat(value);
-					if (lastChar === 'w' && srcExp.test(value)) {
-						src.width = intVal;
-					} else if (lastChar === 'h' && srcExp.test(value)) {
-						src.height = intVal;
-					} else if (lastChar === 'x' && !isNaN(floatVal)) {
-						src.density = floatVal;
-					}
-				});
+                    var value = url.substring(0, url.length - 1),
+                        lastChar = url[url.length - 1],
+                        intVal = parseInt(value, 10),
+                        floatVal = parseFloat(value);
+                    if (lastChar === 'w' && srcExp.test(value)) {
+                        src.width = intVal;
+                    } else if (lastChar === 'h' && srcExp.test(value)) {
+                        src.height = intVal;
+                    } else if (lastChar === 'x' && !isNaN(floatVal)) {
+                        src.density = floatVal;
+                    }
+                });
 
-				return src;
-			});
+                return src;
+            };
+
+            //data URL detected (no split)
+            if (url.indexOf("data:") === 0)
+            {
+                return [urlParser(url)];
+            }
+
+            //regular URL, normal behavior
+            return url.split(',').map(urlParser);
 		},
 
 		/**
@@ -823,6 +832,14 @@
 			if (!url) {
 				return false;
 			}
+			
+            //checking if user defined type is valid
+            if (_self.settings.type) {
+                for (var key in typeMapping) {
+                    if (key === _self.settings.type)
+                        return _self.settings.type;
+                }
+            }
 
 			// Verify the dataType of url according to typeMapping which
 			// has been defined in settings.


### PR DESCRIPTION
Users should provide data type, otherwise… url will opened in iframe.

It's useful function to display images, that are programmatically generated (eg. in JavaScript while exporting canvas, to image, got from APIs in Base64 format, etc.)

In future releases an option to detect type, by Data URL mime type can be added.