### PR TITLE
Disable swipe if user pinch-to-zoom

### DIFF
--- a/src/js/lightcase.js
+++ b/src/js/lightcase.js
@@ -1093,18 +1093,28 @@
 
 				// Enable swiping if activated
 				if (_self.settings.swipe === true) {
-					if ($.isPlainObject($.event.special.swipeleft)) {
+					// Enable swipe on init
+					var viewportScale = 1;
+					if ($.isPlainObject($.event.special.swipeleft) && viewportScale <= 1) {
 						_self.objects.case.on('swipeleft', function (event) {
 							event.preventDefault();
+							// Check for pinch-to-zoom Gesture
+							viewportScale = screen.width / window.innerWidth;
+							if(viewportScale > 1) return;
+
 							_self.objects.next.click();
 							if (_self.isSlideshowEnabled()) {
 								_self._stopTimeout();
 							}
 						});
 					}
-					if ($.isPlainObject($.event.special.swiperight)) {
+					if ($.isPlainObject($.event.special.swiperight) && viewportScale <= 1) {
 						_self.objects.case.on('swiperight', function (event) {
 							event.preventDefault();
+							// Check for pinch-to-zoom Gesture
+							viewportScale = screen.width / window.innerWidth;
+							if(viewportScale > 1) return;
+							
 							_self.objects.prev.click();
 							if (_self.isSlideshowEnabled()) {
 								_self._stopTimeout();


### PR DESCRIPTION
If user use pinch-to-zoom Gesture to zoom image and want to look around, lightcase trigger swipe and go to next/prev image.
To prevent that I was measure difference between size of screen and window width.